### PR TITLE
画像投稿機能を削除-動画投稿機能を後日実装-

### DIFF
--- a/app/javascript/channels/message_channel.js
+++ b/app/javascript/channels/message_channel.js
@@ -16,7 +16,6 @@ consumer.subscriptions.create("MessageChannel", {
     const currentUser = `${data.user.id}`
     const sendUser = `${data.content.user_id}`
     if (currentUser == sendUser) {
-      debugger
       const HTML = `
       <div class="my-content">
         <div class="my-message">
@@ -34,7 +33,6 @@ consumer.subscriptions.create("MessageChannel", {
       messages.insertAdjacentHTML('beforeend', HTML)
       newMessage.value=''
     } else {
-      debugger
       const HTML = `
       <div class="content">
         <div class="upper-message">

--- a/app/views/messages/index.html.erb
+++ b/app/views/messages/index.html.erb
@@ -21,9 +21,10 @@
   <%= form_with model: [@room, @message], method: :post, id: "message_form" do |f| %>
     <div class="input_form">
       <%= f.text_field :content, class: 'form_message', rows: '1', id: "content", placeholder: 'メッセージを送りましょう！' %>
+      <%# <label>
         <span class="glyphicon glyphicon-picture message-picture"></span>
         <%= f.file_field :image, class: 'hidden' %>
-      </label>
+      <%# </label> %>
       <%= f.submit '送信', class: 'send_btn', id: "submit" %>
     </div>
   <% end %>

--- a/app/views/shared/_message.html.erb
+++ b/app/views/shared/_message.html.erb
@@ -9,7 +9,7 @@
       <div class="my-message-content" >
         <%= simple_format(h message.content) %>
       </div>
-      <%= image_tag message.image.variant(resize: '500x500'), class: 'my-message-image' if message.image.attached? %>
+      <%# <%= image_tag message.image.variant(resize: '500x500'), class: 'my-message-image' if message.image.attached? %>
     </div>
   </div>
   <% else %>
@@ -26,7 +26,7 @@
       <div class="message-date">
         <%= l message.created_at %>
       </div>
-      <%= image_tag message.image.variant(resize: '500x500'), class: 'message-image' if message.image.attached? %>
+      <%# <%= image_tag message.image.variant(resize: '500x500'), class: 'message-image' if message.image.attached? %>
     </div>
   </div>
   <% end %>


### PR DESCRIPTION
# What 
画像投稿機能を削除

# Why 
- 動画投稿を行えるようにする為
- 動画投稿の実装を行うまで、シンプルな挙動にする為